### PR TITLE
[Fix] bbox_nms function

### DIFF
--- a/tests/test_utils/test_bounding_box_utils.py
+++ b/tests/test_utils/test_bounding_box_utils.py
@@ -171,12 +171,12 @@ def test_bbox_nms():
     nms_cfg = NMSConfig(min_confidence=0.5, min_iou=0.5)
 
     # Batch 1:
-    #  - box 1 is kept with class 0 as it has a higher confidence than box 4 (box 4 is filtered out)
+    #  - box 1 is kept with class 0 as it has a higher confidence than box 4 i.e. box 4 is filtered out
     #  - box 2 is kept with class 1
-    #  - box 3 is ignored by the confidence filter
+    #  - box 3 is rejected by the confidence filter
     # Batch 2:
-    #  - box 4 is kept with class 0 as it has a higher confidence than box 1 (box 1 is filtered out)
-    #  - box 2 is ignored by the confidence filter
+    #  - box 4 is kept with class 0 as it has a higher confidence than box 1 i.e. box 1 is filtered out
+    #  - box 2 is rejected by the confidence filter
     #  - box 3 is kept with class 2
     expected_output = torch.tensor([
         [[0.0, 0.0, 0.0, 160.0, 120.0, 0.6682],

--- a/tests/test_utils/test_bounding_box_utils.py
+++ b/tests/test_utils/test_bounding_box_utils.py
@@ -146,23 +146,44 @@ def test_anc2box_autoanchor(inference_v7_cfg: Config):
 
 
 def test_bbox_nms():
-    cls_dist = tensor(
-        [[[0.1, 0.7, 0.2], [0.6, 0.3, 0.1]], [[0.4, 0.4, 0.2], [0.5, 0.4, 0.1]]]  # Example class distribution
-    )
-    bbox = tensor(
-        [[[50, 50, 100, 100], [60, 60, 110, 110]], [[40, 40, 90, 90], [70, 70, 120, 120]]],  # Example bounding boxes
-        dtype=float32,
-    )
+    cls_dist = torch.tensor([
+        [[0.7, 0.1, 0.2],     # High confidence, class 0
+         [0.3, 0.6, 0.1],     # High confidence, class 1
+         [-3.0, -2.0, -1.0],  # low confidence, class 2
+         [0.6, 0.2, 0.2]],    # Medium confidence, class 0
+        [[0.55, 0.25, 0.2],   # Medium confidence, class 0
+         [-4.0, -0.5, -2.0],  # low confidence, class 1
+         [0.15, 0.2, 0.65],   # Medium confidence, class 2
+         [0.8, 0.1, 0.1]]     # High confidence, class 0
+    ], dtype=float32)
+
+    bbox = torch.tensor([
+        [[0, 0, 160, 120],      # Overlaps with box 4
+         [160, 120, 320, 240],
+         [0, 120, 160, 240],
+         [16, 12, 176, 132]],
+        [[0, 0, 160, 120],      # Overlaps with box 4
+         [160, 120, 320, 240],
+         [0, 120, 160, 240],
+         [16, 12, 176, 132]]
+    ], dtype=float32)
+
     nms_cfg = NMSConfig(min_confidence=0.5, min_iou=0.5)
 
-    expected_output = [
-        tensor(
-            [
-                [1.0000, 50.0000, 50.0000, 100.0000, 100.0000, 0.6682],
-                [0.0000, 60.0000, 60.0000, 110.0000, 110.0000, 0.6457],
-            ]
-        )
-    ]
+    # Batch 1:
+    #  - box 1 is kept with class 0 as it has a higher confidence than box 4 (box 4 is filtered out)
+    #  - box 2 is kept with class 1
+    #  - box 3 is ignored by the confidence filter
+    # Batch 2:
+    #  - box 4 is kept with class 0 as it has a higher confidence than box 1 (box 1 is filtered out)
+    #  - box 2 is ignored by the confidence filter
+    #  - box 3 is kept with class 2
+    expected_output = torch.tensor([
+        [[0.0, 0.0, 0.0, 160.0, 120.0, 0.6682],
+         [1.0, 160.0, 120.0, 320.0, 240.0, 0.6457]],
+        [[0.0, 16.0, 12.0, 176.0, 132.0, 0.6900],
+         [2.0, 0.0, 120.0, 160.0, 240.0, 0.6570]]
+    ])
 
     output = bbox_nms(cls_dist, bbox, nms_cfg)
 

--- a/tests/test_utils/test_bounding_box_utils.py
+++ b/tests/test_utils/test_bounding_box_utils.py
@@ -146,27 +146,41 @@ def test_anc2box_autoanchor(inference_v7_cfg: Config):
 
 
 def test_bbox_nms():
-    cls_dist = torch.tensor([
-        [[0.7, 0.1, 0.2],     # High confidence, class 0
-         [0.3, 0.6, 0.1],     # High confidence, class 1
-         [-3.0, -2.0, -1.0],  # low confidence, class 2
-         [0.6, 0.2, 0.2]],    # Medium confidence, class 0
-        [[0.55, 0.25, 0.2],   # Medium confidence, class 0
-         [-4.0, -0.5, -2.0],  # low confidence, class 1
-         [0.15, 0.2, 0.65],   # Medium confidence, class 2
-         [0.8, 0.1, 0.1]]     # High confidence, class 0
-    ], dtype=float32)
+    cls_dist = torch.tensor(
+        [
+            [
+                [0.7, 0.1, 0.2],  # High confidence, class 0
+                [0.3, 0.6, 0.1],  # High confidence, class 1
+                [-3.0, -2.0, -1.0],  # low confidence, class 2
+                [0.6, 0.2, 0.2],  # Medium confidence, class 0
+            ],
+            [
+                [0.55, 0.25, 0.2],  # Medium confidence, class 0
+                [-4.0, -0.5, -2.0],  # low confidence, class 1
+                [0.15, 0.2, 0.65],  # Medium confidence, class 2
+                [0.8, 0.1, 0.1],  # High confidence, class 0
+            ],
+        ],
+        dtype=float32,
+    )
 
-    bbox = torch.tensor([
-        [[0, 0, 160, 120],      # Overlaps with box 4
-         [160, 120, 320, 240],
-         [0, 120, 160, 240],
-         [16, 12, 176, 132]],
-        [[0, 0, 160, 120],      # Overlaps with box 4
-         [160, 120, 320, 240],
-         [0, 120, 160, 240],
-         [16, 12, 176, 132]]
-    ], dtype=float32)
+    bbox = torch.tensor(
+        [
+            [
+                [0, 0, 160, 120],  # Overlaps with box 4
+                [160, 120, 320, 240],
+                [0, 120, 160, 240],
+                [16, 12, 176, 132],
+            ],
+            [
+                [0, 0, 160, 120],  # Overlaps with box 4
+                [160, 120, 320, 240],
+                [0, 120, 160, 240],
+                [16, 12, 176, 132],
+            ],
+        ],
+        dtype=float32,
+    )
 
     nms_cfg = NMSConfig(min_confidence=0.5, min_iou=0.5)
 
@@ -178,12 +192,18 @@ def test_bbox_nms():
     #  - box 4 is kept with class 0 as it has a higher confidence than box 1 i.e. box 1 is filtered out
     #  - box 2 is rejected by the confidence filter
     #  - box 3 is kept with class 2
-    expected_output = torch.tensor([
-        [[0.0, 0.0, 0.0, 160.0, 120.0, 0.6682],
-         [1.0, 160.0, 120.0, 320.0, 240.0, 0.6457]],
-        [[0.0, 16.0, 12.0, 176.0, 132.0, 0.6900],
-         [2.0, 0.0, 120.0, 160.0, 240.0, 0.6570]]
-    ])
+    expected_output = torch.tensor(
+        [
+            [
+                [0.0, 0.0, 0.0, 160.0, 120.0, 0.6682],
+                [1.0, 160.0, 120.0, 320.0, 240.0, 0.6457],
+            ],
+            [
+                [0.0, 16.0, 12.0, 176.0, 132.0, 0.6900],
+                [2.0, 0.0, 120.0, 160.0, 240.0, 0.6570],
+            ],
+        ]
+    )
 
     output = bbox_nms(cls_dist, bbox, nms_cfg)
 

--- a/yolo/utils/bounding_box_utils.py
+++ b/yolo/utils/bounding_box_utils.py
@@ -387,7 +387,7 @@ def bbox_nms(cls_dist: Tensor, bbox: Tensor, nms_cfg: NMSConfig, confidence: Opt
     valid_box = bbox[valid_mask.repeat(1, 1, 4)].view(-1, 4)
 
     batch_idx, *_ = torch.where(valid_mask)
-    nms_idx = batched_nms(valid_box, valid_cls, batch_idx, nms_cfg.min_iou)
+    nms_idx = batched_nms(valid_box, valid_con, batch_idx, nms_cfg.min_iou)
     predicts_nms = []
     for idx in range(cls_dist.size(0)):
         instance_idx = nms_idx[idx == batch_idx[nms_idx]]


### PR DESCRIPTION
## Description

According to the documentation of [batched_nms](https://pytorch.org/vision/0.19/generated/torchvision.ops.batched_nms.html?highlight=batched_nms#torchvision.ops.batched_nms), the second argument should the `scores for each one of the boxes` but in the current implementation `valid_cls` is used which is a tensor of class indexes. I believe `valid_con` should be used instead. I tried to update the tests to exhibit the issue.

## Type of Change

Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] The code follows the Python style guide.
- [x] Code and files are well organized.
- [x] All tests pass.
- [x] New code is covered by tests.
- [x] The pull request is directed to the corresponding topic branch.

## Licensing:

By submitting this pull request, I confirm that:

- [x] My contribution is made under the MIT License.
- [x] I have not included any code from questionable or non-compliant sources (GPL, AGPL, ... etc).
- [x] I understand that all contributions to this repository must comply with the MIT License, and I promise that my contributions do not violate this license.
- [x] I have not used any code or content from sources that conflict with the MIT License or are otherwise legally questionable.

