### PR TITLE
[fix] Fixes AMP FutureWarning for depricated import paths.

### DIFF
--- a/yolo/tools/solver.py
+++ b/yolo/tools/solver.py
@@ -11,7 +11,7 @@ import torch
 from loguru import logger
 from pycocotools.coco import COCO
 from torch import Tensor, distributed
-from torch.cuda.amp import GradScaler, autocast
+from torch.amp import GradScaler, autocast
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.data import DataLoader
 
@@ -70,7 +70,7 @@ class ModelTrainer:
         images, targets = images.to(self.device), targets.to(self.device)
         self.optimizer.zero_grad()
 
-        with autocast():
+        with autocast(device_type='cuda'):  # Disabled when not cuda.
             predicts = self.model(images)
             aux_predicts = self.vec2box(predicts["AUX"])
             main_predicts = self.vec2box(predicts["Main"])


### PR DESCRIPTION
## Description
Fix for these warnings:
```
FutureWarning: `torch.cuda.amp.GradScaler(args...)` is deprecated. Please use `torch.amp.GradScaler('cuda', args...)` instead.
FutureWarning: `torch.cuda.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cuda', args...)` instead.
```

## Type of Change
Please delete options that are not relevant.
- [x] Fixes Warnings. Minor import path change to remove `FutureWarning`.

## Checklist:
- [x] The code follows the Python style guide.
- [x] Code and files are well organized.
- [x] All tests pass.
- [x] New code is covered by tests.

## Licensing:
By submitting this pull request, I confirm that:
- [x] My contribution is made under the MIT License.
- [x] I have not included any code from questionable or non-compliant sources (GPL, AGPL, ... etc).
- [x] I understand that all contributions to this repository must comply with the MIT License, and I promise that my contributions do not violate this license.
- [x] I have not used any code or content from sources that conflict with the MIT License or are otherwise legally questionable.