### PR TITLE
Enable openvino deployment

### DIFF
--- a/yolo/config/task/inference.yaml
+++ b/yolo/config/task/inference.yaml
@@ -2,6 +2,7 @@ task: inference
 
 fast_inference:  # onnx, openvino, trt, deploy or Empty
 precision: FP32  # for openvino
+ptq: False  # for openvino
 data:
   source: demo/images/inference/image.png
   image_size: ${image_size}

--- a/yolo/config/task/inference.yaml
+++ b/yolo/config/task/inference.yaml
@@ -1,6 +1,7 @@
 task: inference
 
-fast_inference:  # onnx, trt, deploy or Empty
+fast_inference:  # onnx, openvino, trt, deploy or Empty
+precision: FP32  # for openvino
 data:
   source: demo/images/inference/image.png
   image_size: ${image_size}

--- a/yolo/config/task/validation.yaml
+++ b/yolo/config/task/validation.yaml
@@ -1,5 +1,6 @@
 task: validation
 
+fast_inference:  # onnx, trt, deploy or Empty
 data:
   batch_size: 16
   image_size: ${image_size}

--- a/yolo/config/task/validation.yaml
+++ b/yolo/config/task/validation.yaml
@@ -2,6 +2,7 @@ task: validation
 
 fast_inference:  # onnx, openvino, trt, deploy or Empty
 precision: FP32  # for openvino
+ptq: False  # for openvino
 data:
   batch_size: 16
   image_size: ${image_size}

--- a/yolo/config/task/validation.yaml
+++ b/yolo/config/task/validation.yaml
@@ -1,6 +1,7 @@
 task: validation
 
-fast_inference:  # onnx, trt, deploy or Empty
+fast_inference:  # onnx, openvino, trt, deploy or Empty
+precision: FP32  # for openvino
 data:
   batch_size: 16
   image_size: ${image_size}

--- a/yolo/lazy.py
+++ b/yolo/lazy.py
@@ -6,6 +6,7 @@ import hydra
 project_root = Path(__file__).resolve().parent.parent
 sys.path.append(str(project_root))
 
+from loguru import logger
 from yolo.config.config import Config
 from yolo.model.yolo import create_model
 from yolo.tools.data_loader import create_dataloader
@@ -32,6 +33,8 @@ def main(cfg: Config):
     if cfg.task.task == "train":
         solver = ModelTrainer(cfg, model, converter, progress, device, use_ddp)
     if cfg.task.task == "validation":
+        if cfg.task.fast_inference in ["trt", "deploy"]:
+            logger.warning("⚠️ ONNX is only tested, not responsible about using trt and deploy.")
         solver = ModelValidator(cfg.task, cfg.dataset, model, converter, progress, device)
     if cfg.task.task == "inference":
         solver = ModelTester(cfg, model, converter, progress, device)

--- a/yolo/lazy.py
+++ b/yolo/lazy.py
@@ -34,7 +34,7 @@ def main(cfg: Config):
         solver = ModelTrainer(cfg, model, converter, progress, device, use_ddp)
     if cfg.task.task == "validation":
         if cfg.task.fast_inference in ["trt", "deploy"]:
-            logger.warning("⚠️ ONNX is only tested, not responsible about using trt and deploy.")
+            logger.warning("⚠️ ONNX and OpenVINO are only tested, not responsible about using trt and deploy.")
         solver = ModelValidator(cfg.task, cfg.dataset, model, converter, progress, device)
     if cfg.task.task == "inference":
         solver = ModelTester(cfg, model, converter, progress, device)

--- a/yolo/tools/solver.py
+++ b/yolo/tools/solver.py
@@ -233,8 +233,9 @@ class ModelValidator:
                 self.coco_gt = COCO(json_path)
 
     def solve(self, dataloader, epoch_idx=1):
-        # logger.info("🧪 Start Validation!")
-        self.model.eval()
+        logger.info("🧪 Start Validation!")
+        if isinstance(self.model, torch.nn.Module):
+            self.model.eval()
         predict_json, mAPs = [], defaultdict(list)
         self.progress.start_one_epoch(len(dataloader), task="Validate")
         for batch_size, images, targets, rev_tensor, img_paths in dataloader:

--- a/yolo/utils/deploy_utils.py
+++ b/yolo/utils/deploy_utils.py
@@ -17,7 +17,7 @@ class FastModelLoader:
         self._validate_compiler()
         if cfg.weight == True:
             cfg.weight = Path("weights") / f"{cfg.model.name}.pt"
-        self.model_path = f"{Path(cfg.weight).stem}.{self.compiler}"
+        self.model_path = Path("weights") / f"{Path(cfg.weight).stem}.{self.compiler}"
 
     def _validate_compiler(self):
         if self.compiler not in ["onnx", "trt", "deploy"]:

--- a/yolo/utils/deploy_utils.py
+++ b/yolo/utils/deploy_utils.py
@@ -6,6 +6,7 @@ from torch import Tensor
 
 from yolo.config.config import Config
 from yolo.model.yolo import create_model
+from yolo.tools.data_loader import create_dataloader
 
 
 class FastModelLoader:
@@ -117,6 +118,19 @@ class FastModelLoader:
         except Exception as e:
             logger.warning(f"🈳 Error loading OpenVINO model: {e}")
             model_ov = self._create_openvino_model()
+
+        if self.cfg.task.ptq:
+            if "optimized" in str(self.model_path):
+                logger.info("🚀 PTQ Model is already loaded!")
+            else:
+                import nncf
+                from openvino.runtime import serialize
+                
+                train_dataloader = create_dataloader(self.cfg.task.data, self.cfg.dataset, "train", is_ov_ptq=True)
+                ptq_dataset = nncf.Dataset(train_dataloader, lambda x: x)
+                model_ov = nncf.quantize(model_ov, ptq_dataset, preset=nncf.QuantizationPreset.MIXED)
+                serialize(model_ov, str(self.model_path).replace(".xml", "_optimized.xml"))
+
         return core.compile_model(model_ov, "CPU")
 
     def _create_openvino_model(self):

--- a/yolo/utils/deploy_utils.py
+++ b/yolo/utils/deploy_utils.py
@@ -152,7 +152,7 @@ class FastModelLoader:
             core = Core()
             model_ov = core.read_model(str(self.model_path))
 
-        logger.info(f"📥 ONNX model saved to {self.model_path}")
+        logger.info(f"📥 OpenVINO model saved to {self.model_path}")
         return model_ov
 
     def _load_trt_model(self):


### PR DESCRIPTION
This PR includes:
- [x] Enable validation with deployed models to `onnx` and `openvino` (`trt` and `deploy` are not tested.)
    ```shell
    $ python yolo/lazy.py \
        task=validation \
        name=AnyNameYouWant \ # AnyNameYouWant
        device=cpu \ # hardware cuda, cpu, mps
        model=v9-c \ # model version: v9-c, m, s
        task.fast_inference=onnx # onnx, openvino, trt, deploy
    ```
    - [x] Save deployed models into `weights/` instead of root
        ```shell
        weights
        ├── v9-c.bin
        ├── v9-c.onnx
        ├── v9-c.pt
        └── v9-c.xml
        ```
- [x] Enable openvino deployment
    - To deploy the model to openvino
    ```shell
    $ pip install openvino
    $ python yolo/lazy.py task=validation model=v9-c device=cpu task.fast_inference=openvino
    ...
    [08/28 12:50:24] WARNING | __ Error loading OpenVINO model: Exception from src/inference/src/cpp/core.cpp:90:
    Check 'util::directory_exists(path) || util::file_exists(path)' failed at src/frontends/common/src/frontend.cpp:113:
    FrontEnd API failed with GeneralFailure
    ir: Could not open the file: "weights/v9-c.xml"
                                                                                                                                                                                                                                                                                                                            
    [08/28 12:50:26]   INFO  | 📥 OpenVINO model saved to weights/v9-c.xml
    ...
    
    # for fp16 compression
    $ python yolo/lazy.py task=validation model=v9-c device=cpu task.fast_inference=openvino task.precision=FP16
    ...
    [08/28 12:59:35] WARNING | __ Error loading OpenVINO model: Exception from src/inference/src/cpp/core.cpp:90:
    Check 'util::directory_exists(path) || util::file_exists(path)' failed at src/frontends/common/src/frontend.cpp:113:
    FrontEnd API failed with GeneralFailure:
    ir: Could not open the file: "weights/v9-c_fp16.xml"

    [08/28 12:59:37]   INFO  | 📥 OpenVINO model saved to weights/v9-c_fp16.xml
    ...
    ```
- [x] Enable post-training quantization using nncf
    ```shell
    $ pip install nncf
    $ python yolo/lazy.py task=validation model=v9-c device=cpu task.fast_inference=openvino task.ptq=True # ptq to uint8
    ...
    [08/28 10:25:00]   INFO  | 🚀 Using OpenVINO as MODEL frameworks!
    INFO:nncf:NNCF initialized successfully. Supported frameworks detected: torch, onnx, openvino
    ...
    Statistics collection _____________________________________________________________________________________________________ 100% 300/300 _ 0:24:38 _ 0:00:00
    Applying Fast Bias correction _____________________________________________________________________________________________ 100% 291/291 _ 0:00:37 _ 0:00:00
    ...
    ```