### PR TITLE
[Fix] Fix validator to handle custom datasets with txt files

### DIFF
--- a/yolo/tools/solver.py
+++ b/yolo/tools/solver.py
@@ -228,8 +228,8 @@ class ModelValidator:
 
         with contextlib.redirect_stdout(io.StringIO()):
             # TODO: load with config file
-            json_path, _ = locate_label_paths(Path(dataset_cfg.path), dataset_cfg.get("validation", "val"))
-            if json_path:
+            json_path, file_type = locate_label_paths(Path(dataset_cfg.path), dataset_cfg.get("validation", "val"))
+            if json_path and file_type == "json":
                 self.coco_gt = COCO(json_path)
 
     def solve(self, dataloader, epoch_idx=1):


### PR DESCRIPTION
## Description

When the input validation dataset is using txt labels the Validator throws exception on these lines:

https://github.com/WongKinYiu/YOLO/blob/8228669808a626fc5f9c233fdb35550b5e041fae/yolo/tools/solver.py#L231-L233

Add a condition for txt files to bypass this if.

Closes #94 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] The code follows the Python style guide.
- [x] Code and files are well organized.
- [ ] All tests pass.
- [ ] New code is covered by tests.
- [ ] The pull request is directed to the corresponding topic branch.
- [ ] [Optional] We would be very happy if gitmoji :technologist: could be used to assist the commit message :speech_balloon:!

## Licensing:

By submitting this pull request, I confirm that:

- [ ] My contribution is made under the MIT License.
- [ ] I have not included any code from questionable or non-compliant sources (GPL, AGPL, ... etc).
- [ ] I understand that all contributions to this repository must comply with the MIT License, and I promise that my contributions do not violate this license.
- [ ] I have not used any code or content from sources that conflict with the MIT License or are otherwise legally questionable.

