### PR TITLE
 🐛 [Fix] learning rate schedule and momentum value

### DIFF
--- a/yolo/utils/model_utils.py
+++ b/yolo/utils/model_utils.py
@@ -52,9 +52,9 @@ def create_optimizer(model: YOLO, optim_cfg: OptimizerConfig) -> Optimizer:
     conv_params = [p for name, p in model.named_parameters() if "weight" in name and "bn" not in name]
 
     model_parameters = [
-        {"params": bias_params, "momentum": 0.8, "weight_decay": 0},
-        {"params": conv_params, "momentum": 0.8},
-        {"params": norm_params, "momentum": 0.8, "weight_decay": 0},
+        {"params": bias_params, "weight_decay": 0},
+        {"params": conv_params},
+        {"params": norm_params, "weight_decay": 0},
     ]
 
     def next_epoch(self, batch_num):
@@ -76,7 +76,7 @@ def create_optimizer(model: YOLO, optim_cfg: OptimizerConfig) -> Optimizer:
     optimizer_class.next_epoch = next_epoch
 
     optimizer = optimizer_class(model_parameters, **optim_cfg.args)
-    optimizer.max_lr = [0.1, 0, 0]
+    optimizer.max_lr = [0, 0, 0]
     return optimizer
 
 


### PR DESCRIPTION
Set the initial optimizer.max_lr value to be zero for each parameter group. Removed the "baked in" 0.8 optimizer momentum values, it will be initialized with the one provided in the train config file instead.

Fixes #122 