### PR TITLE
:bug: [Fix] add missing stride config to v9-m and v9-s

### DIFF
--- a/yolo/config/model/v9-m.yaml
+++ b/yolo/config/model/v9-m.yaml
@@ -2,6 +2,7 @@ name: v9-m
 
 anchor:
   reg_max: 16
+  strides: [8, 16, 32]
 
 model:
   backbone:

--- a/yolo/config/model/v9-s.yaml
+++ b/yolo/config/model/v9-s.yaml
@@ -2,6 +2,7 @@ name: v9-s
 
 anchor:
   reg_max: 16
+  strides: [8, 16, 32]
 
 model:
   backbone:


### PR DESCRIPTION
## Description

I encountered an error while trying to train v9-m or v9-s models with the command:

```console
yolo task=train model=v9-s
```

This results in a missing stride error:

```console
[11/17/24 09:11:22] INFO     🧘 Found no stride of model, performed a dummy test for auto-anchor size                                                                                                                       bounding_box_utils.py:307
--- Logging error ---
Traceback (most recent call last):
  ...
RuntimeError: Input type (torch.cuda.FloatTensor) and weight type (torch.FloatTensor) should be the same
```

It seems like the model's stride wasn't defined in the respective m and s configs, leading to this error. Was the omission of the strides intentional?

To resolve this, I've added the missing strides in this pull request to ensure the training for these models works as expected.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] The code follows the Python style guide.
- [x] Code and files are well organized.
- [x] All tests pass.
- [ ] New code is covered by tests _(as of right now, v9-s and v9-m training is not tested. Integration tests for all default model configs could be a solution in the future, I might create an issue for that soon)_.
- [ ] The pull request is directed to the corresponding topic branch _(I was not 100% sure to add it to MODEL since it is just a configuration issue)_.
- [x] [Optional] We would be very happy if gitmoji 🧑‍💻 could be used to assist the commit message 💬!

## Licensing

By submitting this pull request, I confirm that:

- [x] My contribution is made under the MIT License.

- [x] I have not included any code from questionable or non-compliant sources (GPL, AGPL, ... etc).

- [x] I understand that all contributions to this repository must comply with the MIT License, and I promise that my contributions do not violate this license.

- [x] I have not used any code or content from sources that conflict with the MIT License or are otherwise legally questionable.