### PR TITLE
Fix point filtering logic in `load_valid_labels()`

### DIFF
--- a/yolo/tools/data_loader.py
+++ b/yolo/tools/data_loader.py
@@ -140,10 +140,14 @@ class YoloDataset(Dataset):
         for seg_data in seg_data_one_img:
             cls = seg_data[0]
             points = np.array(seg_data[1:]).reshape(-1, 2)
-            valid_points = points[(points >= 0) & (points <= 1)].reshape(-1, 2)
-            if valid_points.size > 1:
-                bbox = torch.tensor([cls, *valid_points.min(axis=0), *valid_points.max(axis=0)])
-                bboxes.append(bbox)
+
+            if not np.any((points >= 0) & (points <= 1)):
+                continue
+
+            valid_points = np.clip(points, 0, 1)
+
+            bbox = torch.tensor([cls, *valid_points.min(axis=0), *valid_points.max(axis=0)])
+            bboxes.append(bbox)
 
         if bboxes:
             return torch.stack(bboxes)


### PR DESCRIPTION
This PR addresses the filtering issue in the `load_valid_labels()` function, where element-wise filtering can disrupt the 2D structure of coordinate pairs (Issue #156).

Currently:
```python
valid_points = points[(points >= 0) & (points <= 1)].reshape(-1, 2)
```
This element-wise approach can cause inconsistent row structures. To fix this, we can adopt row-wise filtering:
```python
valid_points = points[np.all((points >= 0) & (points <= 1), axis=1)]
```
This fix ensures that x-y coordinate pairs remain intact.

However, filtering out each point individually can still break bounding boxes that include coordinates outside `[0, 1]`. To address this more fundamentally, I propose clipping any out-of-range coordinates to `[0, 1]` whenever at least one point of the bounding box lies within the frame. If all points are completely outside the frame, we ignore the bounding box as invalid. This approach preserves as much of the bounding box as possible.

Visualization of filtered bounding boxes (representing heads):
- Current filtering logic:
![Image](https://github.com/user-attachments/assets/172557f7-118e-4ef6-807c-c729909d48c4)

- Fixed filtering logic:
![Image](https://github.com/user-attachments/assets/87122832-7f28-454f-bc57-5718143aca72)

I look forward to your feedback on this change. Thank you!