### PR TITLE
feat: add lazy imports for faster startup time

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ einops
 faster-coco-eval
 graphviz
 hydra-core
+lazy-loader
 lightning
 loguru
 numpy

--- a/yolo/__init__.py
+++ b/yolo/__init__.py
@@ -1,33 +1,78 @@
-from yolo.config.config import Config, NMSConfig
-from yolo.model.yolo import create_model
-from yolo.tools.data_loader import AugmentationComposer, create_dataloader
-from yolo.tools.drawer import draw_bboxes
-from yolo.tools.solver import TrainModel
-from yolo.utils.bounding_box_utils import Anc2Box, Vec2Box, bbox_nms, create_converter
-from yolo.utils.deploy_utils import FastModelLoader
-from yolo.utils.logging_utils import (
-    ImageLogger,
-    YOLORichModelSummary,
-    YOLORichProgressBar,
-)
-from yolo.utils.model_utils import PostProcess
+"""
+The MIT YOLO rewrite
+"""
 
-all = [
-    "create_model",
-    "Config",
-    "YOLORichProgressBar",
-    "NMSConfig",
-    "YOLORichModelSummary",
-    "validate_log_directory",
-    "draw_bboxes",
-    "Vec2Box",
-    "Anc2Box",
-    "bbox_nms",
-    "create_converter",
-    "AugmentationComposer",
-    "ImageLogger",
-    "create_dataloader",
-    "FastModelLoader",
-    "TrainModel",
-    "PostProcess",
-]
+__autogen__ = """
+mkinit ~/code/YOLO-v9/yolo/__init__.py --nomods --write --lazy-loader
+
+# Check to see how long it takes to run a simple help command
+time python -m yolo.lazy --help
+"""
+
+__submodules__ = {
+    'config.config': ['Config', 'NMSConfig'],
+    'model.yolo': ['create_model'],
+    'tools.data_loader': ['AugmentationComposer', 'create_dataloader'],
+    'tools.drawer': ['draw_bboxes'],
+    'tools.solver': ['TrainModel'],
+    'utils.bounding_box_utils': ['Anc2Box', 'Vec2Box', 'bbox_nms', 'create_converter'],
+    'utils.deploy_utils': ['FastModelLoader'],
+    'utils.logging_utils': [
+        'ImageLogger', 'YOLORichModelSummary',
+        'YOLORichProgressBar',
+        'validate_log_directory'
+    ],
+    'utils.model_utils': ['PostProcess'],
+}
+
+
+import lazy_loader
+
+
+__getattr__, __dir__, __all__ = lazy_loader.attach(
+    __name__,
+    submodules={},
+    submod_attrs={
+        'config.config': [
+            'Config',
+            'NMSConfig',
+        ],
+        'model.yolo': [
+            'create_model',
+        ],
+        'tools.data_loader': [
+            'AugmentationComposer',
+            'create_dataloader',
+        ],
+        'tools.drawer': [
+            'draw_bboxes',
+        ],
+        'tools.solver': [
+            'TrainModel',
+        ],
+        'utils.bounding_box_utils': [
+            'Anc2Box',
+            'Vec2Box',
+            'bbox_nms',
+            'create_converter',
+        ],
+        'utils.deploy_utils': [
+            'FastModelLoader',
+        ],
+        'utils.logging_utils': [
+            'ImageLogger',
+            'YOLORichModelSummary',
+            'YOLORichProgressBar',
+            'validate_log_directory',
+        ],
+        'utils.model_utils': [
+            'PostProcess',
+        ],
+    },
+)
+
+__all__ = ['Anc2Box', 'AugmentationComposer', 'Config', 'FastModelLoader',
+           'ImageLogger', 'NMSConfig', 'PostProcess', 'TrainModel', 'Vec2Box',
+           'YOLORichModelSummary', 'YOLORichProgressBar', 'bbox_nms',
+           'create_converter', 'create_dataloader', 'create_model',
+           'draw_bboxes', 'validate_log_directory']

--- a/yolo/lazy.py
+++ b/yolo/lazy.py
@@ -2,20 +2,19 @@ import sys
 from pathlib import Path
 
 import hydra
-from lightning import Trainer
+from omegaconf.dictconfig import DictConfig
 
 project_root = Path(__file__).resolve().parent.parent
 sys.path.append(str(project_root))
 
-from yolo.config.config import Config
-from yolo.tools.solver import InferenceModel, TrainModel, ValidateModel
-from yolo.utils.logging_utils import setup
-
 
 @hydra.main(config_path="config", config_name="config", version_base=None)
-def main(cfg: Config):
+def main(cfg: DictConfig):
+    from yolo.utils.logging_utils import setup
     callbacks, loggers, save_path = setup(cfg)
 
+    from lightning import Trainer
+    from yolo.tools.solver import InferenceModel, TrainModel, ValidateModel
     trainer = Trainer(
         accelerator="auto",
         max_epochs=getattr(cfg.task, "epoch", None),


### PR DESCRIPTION
For easier review, this is broken out feature I wrote in https://github.com/WongKinYiu/YOLO/pull/150

This uses lazy imports 

### Issue Being Solved

The problem is that the startup time of the `yolo/lazy.py` script is very long because `yolo/__init__.py` explicitly imports a lot of heavyweight dependencies.

Previously running: `time python -m yolo.lazy --help` took 3 seconds on my machine. After this patch it now takes 0.3 seconds, a 10x improvement.

It works using the [lazy-loader](https://pypi.org/project/lazy-loader/) module. Instead of explicitly importing everything, it only will import them if they are used. You can also specify the `EAGER_IMPORT=1` environment variable to have it import everything on startup as it used to. E.g, the following command will revert to the old 3 second startup time:

```bash
time EAGER_IMPORT=True python -m yolo.lazy --help
```

Additionally I had to move a few imports in `lazy.py` itself into the main function so it can hit the hydra code before it starts to import all of lightning. 

### Note on mkinit

Note, that I wrote this using [mkinit](https://github.com/Erotemic/mkinit) autogeneration, which is why there is a `__submodules__` and `__autogen__` definition at the top. Technically this can be removed. But it also lets you regenerate the `__init__.py` file more easily if anything changes. It can even reconstruct the original explicit definition of the file with:

```bash
mkinit ./yolo/__init__.py --nomods --write
```

### On Dependencies

This does add a dependency on lazy-loader, but that could be removed by defining the `lazy_loader.attach` directly in the `__init__.py`, but it is a bit ugly, so I tend to prefer using the lightweight package.  Running `mkinit` with `--lazy` instead of `--lazy-loader` will generate this variant of the code.