### PR TITLE
:bug: [FIX] filter_data

### DIFF
--- a/yolo/tools/data_loader.py
+++ b/yolo/tools/data_loader.py
@@ -49,7 +49,7 @@ class YoloDataset(Dataset):
         Returns:
             dict: The loaded data from the cache for the specified phase.
         """
-        cache_path = dataset_path / f"{phase_name}.pache"
+        cache_path = dataset_path / f"{phase_name}.cache"
 
         if not cache_path.exists():
             logger.info(f":factory: Generating {phase_name} cache")
@@ -87,7 +87,7 @@ class YoloDataset(Dataset):
             data_type, adjust_path = "txt", True
             # TODO: should i sort by name?
             with open(file_list, "r") as file:
-                images_list = [dataset_path / line.rstrip() for line in file]
+                images_list = [images_path / line.rstrip() for line in file]
             labels_list = [
                 Path(str(image_path).replace("images", "labels")).with_suffix(".txt") for image_path in images_list
             ]


### PR DESCRIPTION
*Issue:* 
- The commit 9818478df2348e955bca0aabf6c366340ce3763b changes the location where the `images_list` variable points to. Loading in a standard YOLO dataset with the default file structure will break as a result (`get_data', line 169).

*Fix:*
- Images are now loaded from the correct `images_path` instead of `dataset_path`
  - This also impacts `labels_path`, since this is based on `images_path`
- Typo "pache" now reverted to "cache" - While not a bug as such, I do not believe this was intentional

*Further remarks:*
- I did not touch the TODO in line 88 regarding sorting by name. 